### PR TITLE
11 wrote unit tests for NetworkManager

### DIFF
--- a/CandySpace.xcodeproj/project.pbxproj
+++ b/CandySpace.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		021A54FB2ABA2FF300C5AC29 /* GalleryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021A54FA2ABA2FF300C5AC29 /* GalleryViewController.swift */; };
 		02E207862ABA15A800D0830F /* PhotoCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E207852ABA15A800D0830F /* PhotoCollectionViewCell.swift */; };
 		04267CF82ABB213A00C7856F /* GalleryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04267CF72ABB213A00C7856F /* GalleryViewModelTests.swift */; };
+		0440305A2ABC97EA005103DC /* NetworkManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 044030592ABC97EA005103DC /* NetworkManagerMock.swift */; };
 		2F29B0012AB4D4EB005EB01E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F29B0002AB4D4EB005EB01E /* AppDelegate.swift */; };
 		2F29B0032AB4D4EB005EB01E /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F29B0022AB4D4EB005EB01E /* SceneDelegate.swift */; };
 		2F29B0052AB4D4EB005EB01E /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F29B0042AB4D4EB005EB01E /* ViewController.swift */; };
@@ -47,6 +48,8 @@
 		021A54FA2ABA2FF300C5AC29 /* GalleryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryViewController.swift; sourceTree = "<group>"; };
 		02E207852ABA15A800D0830F /* PhotoCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoCollectionViewCell.swift; sourceTree = "<group>"; };
 		04267CF72ABB213A00C7856F /* GalleryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryViewModelTests.swift; sourceTree = "<group>"; };
+		04267F572ABB87F600C7856F /* CandySpace.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = CandySpace.xctestplan; sourceTree = "<group>"; };
+		044030592ABC97EA005103DC /* NetworkManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManagerMock.swift; sourceTree = "<group>"; };
 		2F29AFFD2AB4D4EB005EB01E /* CandySpace.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CandySpace.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2F29B0002AB4D4EB005EB01E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		2F29B0022AB4D4EB005EB01E /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -120,6 +123,7 @@
 		2F29AFF42AB4D4EB005EB01E = {
 			isa = PBXGroup;
 			children = (
+				04267F572ABB87F600C7856F /* CandySpace.xctestplan */,
 				2F29AFFF2AB4D4EB005EB01E /* CandySpace */,
 				2F29B0162AB4D4EC005EB01E /* CandySpaceTests */,
 				2F29B0202AB4D4EC005EB01E /* CandySpaceUITests */,
@@ -159,6 +163,7 @@
 			children = (
 				2F29B0172AB4D4EC005EB01E /* CandySpaceTests.swift */,
 				04267CF72ABB213A00C7856F /* GalleryViewModelTests.swift */,
+				044030592ABC97EA005103DC /* NetworkManagerMock.swift */,
 			);
 			path = CandySpaceTests;
 			sourceTree = "<group>";
@@ -346,6 +351,7 @@
 			files = (
 				2F29B0182AB4D4EC005EB01E /* CandySpaceTests.swift in Sources */,
 				04267CF82ABB213A00C7856F /* GalleryViewModelTests.swift in Sources */,
+				0440305A2ABC97EA005103DC /* NetworkManagerMock.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CandySpace.xcodeproj/xcshareddata/xcschemes/CandySpace.xcscheme
+++ b/CandySpace.xcodeproj/xcshareddata/xcschemes/CandySpace.xcscheme
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2F29AFFC2AB4D4EB005EB01E"
+               BuildableName = "CandySpace.app"
+               BlueprintName = "CandySpace"
+               ReferencedContainer = "container:CandySpace.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:CandySpace.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2F29B0122AB4D4EC005EB01E"
+               BuildableName = "CandySpaceTests.xctest"
+               BlueprintName = "CandySpaceTests"
+               ReferencedContainer = "container:CandySpace.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2F29B01C2AB4D4EC005EB01E"
+               BuildableName = "CandySpaceUITests.xctest"
+               BlueprintName = "CandySpaceUITests"
+               ReferencedContainer = "container:CandySpace.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2F29AFFC2AB4D4EB005EB01E"
+            BuildableName = "CandySpace.app"
+            BlueprintName = "CandySpace"
+            ReferencedContainer = "container:CandySpace.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2F29AFFC2AB4D4EB005EB01E"
+            BuildableName = "CandySpace.app"
+            BlueprintName = "CandySpace"
+            ReferencedContainer = "container:CandySpace.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/CandySpace.xctestplan
+++ b/CandySpace.xctestplan
@@ -1,0 +1,37 @@
+{
+  "configurations" : [
+    {
+      "id" : "7992B227-CCED-45A8-92BB-71685F807219",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:CandySpace.xcodeproj",
+      "identifier" : "2F29AFFC2AB4D4EB005EB01E",
+      "name" : "CandySpace"
+    }
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:CandySpace.xcodeproj",
+        "identifier" : "2F29B0122AB4D4EC005EB01E",
+        "name" : "CandySpaceTests"
+      }
+    },
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:CandySpace.xcodeproj",
+        "identifier" : "2F29B01C2AB4D4EC005EB01E",
+        "name" : "CandySpaceUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/CandySpace/GalleryViewModel.swift
+++ b/CandySpace/GalleryViewModel.swift
@@ -9,7 +9,7 @@ import Foundation
 enum NetworkError: Error {
     case invalidURL
     case requestFailed
-    case noetworkManagerFailed
+    case networkManagerFailed
     // Add more error cases as needed
 }
 
@@ -18,17 +18,20 @@ class GalleryViewModel {
     init(initNetworkManager: NetworkManagerHelper) {
         networkManager = initNetworkManager
     }
+    
     lazy var hitsArray = HitArrays()
     func getImageGallery(searchParameter: String) async -> Result<Gallery, NetworkError> {
-        guard let url = CandySpaceURL.getGalleryurl(query: searchParameter) else {
+    guard let url = CandySpaceURL.getGalleryurl(query: searchParameter) else {
             return .failure(.invalidURL)
         }
         do {
+            
             let gallery = try await networkManager.taskForGETRequest(url: url, responseType: Gallery.self)
             self.hitsArray = gallery.hits ?? []
             return .success(gallery)
+            
         } catch {
-            return .failure(.noetworkManagerFailed)
+            return .failure(.networkManagerFailed)
         }
     }
 }

--- a/CandySpace/NetworkManager.swift
+++ b/CandySpace/NetworkManager.swift
@@ -22,6 +22,7 @@ struct CandySpaceURL {
         return url
     }
 }
+
 class NetworkManager: NetworkManagerHelper {
     public func taskForGETRequest<ResponseType: Decodable>
     (url: URL, responseType: ResponseType.Type) async throws -> ResponseType {

--- a/CandySpace/ViewController/GalleryViewController.swift
+++ b/CandySpace/ViewController/GalleryViewController.swift
@@ -141,3 +141,4 @@ extension UIImageView {
         }
     }
 }
+

--- a/CandySpaceTests/GalleryViewModelTests.swift
+++ b/CandySpaceTests/GalleryViewModelTests.swift
@@ -6,36 +6,67 @@
 //
 
 import XCTest
+import Combine
 @testable import CandySpace
 
 final class GalleryViewModelTests: XCTestCase {
     
-    var viewModel: GalleryViewModel?
+    var viewModel = GalleryViewModel(initNetworkManager: MockNetworkManager())
+//    var networkManagerMock = NetworkManager()
      
     override func setUp() {
         super.setUp()
-        var networkManagerMock = NetworkManager()
-        viewModel = GalleryViewModel(initNetworkManager: networkManagerMock)
+       
+//        viewModel = GalleryViewModel(initNetworkManager: networkManagerMock)
     }
 
     override func tearDown() {
-        viewModel = nil
+//        viewModel = nil
         super.tearDown()
     }
     
-    func testFetchGallerySuccess()  async {
-        let expectedTotalHits = 500
-        let expectedTotal = 242563
-        let expectedHits = 20
-        
-        let result =  await viewModel!.getImageGallery(searchParameter: "nature")
-        switch result {
-        case .success(let res):
-            XCTAssertEqual(res.totalHits,expectedTotalHits,"Total Hits are not equal")
-            XCTAssertEqual(res.total,expectedTotal,"Total are not equal")
-            XCTAssertEqual(res.hits?.count,expectedHits,"Hits are not equal")
-        case .failure(let error):
-            print(error)
+//    func testFetchGallerySuccess()  async {
+//        let expectedTotalHits = 500
+//       // let expectedTotal = 242563
+//        let expectedHits = 20
+//
+//        let result =  await viewModel.getImageGallery(searchParameter: "nature")
+//        switch result {
+//        case .success(let res):
+//            XCTAssertEqual(res.totalHits,expectedTotalHits,"Total Hits are not equal")
+//          //  XCTAssertEqual(res.total,expectedTotal,"Total are not equal")
+//            XCTAssertEqual(res.hits?.count,expectedHits,"Hits are not equal")
+//        case .failure(let error):
+//            print(error)
+//        }
+//    }
+    
+    func testGetImageGallerySuccess() {
+        Task {
+            let result = await viewModel.getImageGallery(searchParameter: "nature")
+            switch result {
+            case .success(let success):
+                XCTAssertEqual(success.hits?.count, 2)
+                XCTAssertEqual(success.total, 1)
+                XCTAssertEqual(success.totalHits, 2)
+            case .failure(let failure):
+                print(failure)
+            }
+        }
+    }
+    
+    func testGetImageGalleryFailure() {
+        Task {
+            let networkMock = MockNetworkManager()
+            networkMock.success = false
+            let result = await viewModel.getImageGallery(searchParameter: "nature")
+            switch result {
+            case .success(let success):
+                print(success)
+            case .failure(let failure):
+                print(failure)
+                XCTAssertEqual(.networkManagerFailed, failure)
+            }
         }
     }
 

--- a/CandySpaceTests/NetworkManagerMock.swift
+++ b/CandySpaceTests/NetworkManagerMock.swift
@@ -1,0 +1,57 @@
+//
+//  NetworkManagerMock.swift
+//  CandySpaceTests
+//
+//  Created by William Rozier on 9/21/23.
+//
+
+import XCTest
+
+@testable import  CandySpace
+
+class MockNetworkManager: NetworkManagerHelper {
+    var success = false
+    
+    func taskForGETRequest<ResponseType>(url: URL, responseType: ResponseType.Type) async throws -> ResponseType where ResponseType : Decodable {
+        if success {
+            return Gallery.getMockGallery() as! ResponseType
+        } else {
+            let jsondecoder = JSONDecoder()
+            let data = Data()
+            let failData = try jsondecoder.decode(MockGallery.self, from: data)
+            print("Fail: \(failData)")
+            return failData as! ResponseType
+        }
+    }
+}
+struct MockGallery: Decodable {
+    let tota: Int
+    let totalHit: Int
+    let hits: [Hits]
+}
+
+extension Gallery {
+    static func getMockGallery() -> Gallery {
+        let hits = [Hits(id: 0, pageURL: nil, type: nil, tags: nil, previewURL: nil, previewWidth: nil, previewHeight: nil, webformatURL: nil, webformatWidth: nil, webformatHeight: nil, largeImageURL: nil, imageWidth: nil, imageHeight: nil, imageSize: nil, views: nil, downloads: nil, collections: nil, likes: nil, comments: nil, userId: nil, user: nil, userImageURL: nil), Hits(id: 1, pageURL: nil, type: nil, tags: nil, previewURL: nil, previewWidth: nil, previewHeight: nil, webformatURL: nil, webformatWidth: nil, webformatHeight: nil, largeImageURL: nil, imageWidth: nil, imageHeight: nil, imageSize: nil, views: nil, downloads: nil, collections: nil, likes: nil, comments: nil, userId: nil, user: nil, userImageURL: nil)]
+        return Gallery(total: 1, totalHits: 2, hits: hits)
+    }
+}
+
+//final class NetworkManagerHelperMock: XCTestCase  {
+//
+//    var mockGalleryResponse: Gallery?
+//    var shouldThrowError = false
+//
+//    // Implement the required methods of NetworkManagerHelper protocol
+//    func taskForGETRequest<T: Decodable>(url: URL, responseType: T.Type) async throws -> T {
+//        if shouldThrowError {
+//            throw NetworkError.networkManagerFailed
+//        }
+//
+//        if let gallery = mockGalleryResponse as? T {
+//            return gallery
+//        }
+//
+//        throw NetworkError.networkManagerFailed
+//    }
+//}


### PR DESCRIPTION
Ran XCTest Cases for NetworkManagerMock , and ran Code Coverage.

CandySpaceUITests-Runner[22895:3572203] Running tests...
Test Suite 'CandySpaceUITests' started at 2023-09-21 17:43:42.076
Test Case '-[CandySpaceUITests.CandySpaceUITests testExample]' started.
    t =     0.00s Start Test at 2023-09-21 17:43:42.079
    t =     0.09s Set Up
    t =     0.13s Open Gevcorst.CandySpace
    t =     0.17s     Launch Gevcorst.CandySpace
    t =     5.10s         Setting up automation session
    t =     5.15s         Wait for Gevcorst.CandySpace to idle
    t =     6.19s Tear Down
Test Case '-[CandySpaceUITests.CandySpaceUITests testExample]' passed (6.401 seconds).
Test Case '-[CandySpaceUITests.CandySpaceUITests testLaunchPerformance]' started.
    t =     0.00s Start Test at 2023-09-21 17:43:48.480
    t =     0.03s Set Up
    t =     0.07s Open Gevcorst.CandySpace
    t =     0.09s     Launch Gevcorst.CandySpace
    t =     0.09s         Terminate Gevcorst.CandySpace:22960
    t =     3.08s         Setting up automation session
    t =     4.30s         Wait for Gevcorst.CandySpace to idle
    t =    17.38s Open Gevcorst.CandySpace
    t =    17.44s     Launch Gevcorst.CandySpace
    t =    17.44s         Terminate Gevcorst.CandySpace:23032
    t =    21.04s         Setting up automation session
    t =    22.39s         Wait for Gevcorst.CandySpace to idle
